### PR TITLE
feat: support attribute map

### DIFF
--- a/test/hiccup_find/core_test.cljc
+++ b/test/hiccup_find/core_test.cljc
@@ -4,13 +4,30 @@
             [hiccup-find.core :refer [hiccup-find
                                       hiccup-string
                                       hiccup-symbol-matches?
-                                      hiccup-text]]))
+                                      hiccup-text
+                                      hiccup-attrs-parts
+                                      hiccup-symbol-parts
+                                      normalized-symbol]]))
 
 (deftest test-hiccup-symbol-matches?
   (is (hiccup-symbol-matches? :p :p.class))
   (is (not (hiccup-symbol-matches? :p.class :p)))
   (is (hiccup-symbol-matches? :.class :p.class.more))
   (is (hiccup-symbol-matches? :p.more.class :p.class.more)))
+
+(deftest test-hiccup-attrs-parts []
+  (is (= {:id "quux" :classes ["foo" "bar"]}
+         (hiccup-attrs-parts [:div.x.y#z {:id "quux" :class "foo bar"}]))))
+
+(deftest test-hiccup-symbol-parts []
+  (is (= {:tag "div" :id "quux" :classes ["foo" "bar"]}
+         (hiccup-symbol-parts [:div.foo.bar#quux]))))
+
+(deftest test-normalized-symbol
+  (is (= :div.foo.bar#quux (normalized-symbol [:div.foo.bar#quux])))
+  (is (= :div.foo.bar#quux (normalized-symbol [:div.foo#quux {:class "bar"}])))
+  (is (= :div.foo.bar#quux (normalized-symbol [:div.foo {:class "bar" :id "quux"}])))
+  (is (= :div.foo.bar#quux (normalized-symbol [:div {:class "foo bar" :id "quux"}]))))
 
 (deftest test-hiccup-find
 


### PR DESCRIPTION
Normalize the hiccup symbol for the comparison purposes, so that the
attributes map :class and :id are respected.

I.e. given the hiccup node
[:div.foo {:class "bar" :id "quux"}]

it should match

[:div.foo]
[:div.bar]
[:div.foo.bar]
[:div#quux]

etc.